### PR TITLE
Fix score display on Py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,108 @@
 *.py[cod]
 docs/_build/*
 docs/_static/*
+.coverage
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=rgkit/ --cov=test/

--- a/rgkit/render/render.py
+++ b/rgkit/render/render.py
@@ -275,8 +275,8 @@ class Render(object):
         for layer in self._layers:
             self._win.tag_raise(layer)
 
-    def draw_text(self, loc, text, color=None):
-        layer_id = 'layer %d' % 9
+    def draw_text(self, loc, text, color=None, layer=9):
+        layer_id = 'layer %d' % layer
         self._layers[layer_id] = None
         x, y = self.grid_to_xy(loc)
         item = self._win.create_text(
@@ -403,11 +403,9 @@ class Render(object):
                     loc, fill=self.get_bg_color(loc), layer=1, width=0)
         # draw text labels
         text_color = rgb_to_hex(*render_settings.text_color)
-        # for some reason this kills the grid cell labels in Py3
-        if sys.version_info[0] == 2:
-            for y in range(settings.board_size):
-                self.draw_text((y, 0), str(y), color=text_color)
-                self.draw_text((0, y), str(y), color=text_color)
+        for y in range(settings.board_size):
+            self.draw_text((y, 0), str(y), color=text_color, layer=9)
+            self.draw_text((0, y), str(y), color=text_color, layer=9)
 
     def update_sprites_new_turn(self):
         for sprite in self._sprites:

--- a/rgkit/render/render.py
+++ b/rgkit/render/render.py
@@ -403,9 +403,11 @@ class Render(object):
                     loc, fill=self.get_bg_color(loc), layer=1, width=0)
         # draw text labels
         text_color = rgb_to_hex(*render_settings.text_color)
-        for y in range(settings.board_size):
-            self.draw_text((y, 0), str(y), color=text_color)
-            self.draw_text((0, y), str(y), color=text_color)
+        # for some reason this kills the grid cell labels in Py3
+        if sys.version_info[0] == 2:
+            for y in range(settings.board_size):
+                self.draw_text((y, 0), str(y), color=text_color)
+                self.draw_text((0, y), str(y), color=text_color)
 
     def update_sprites_new_turn(self):
         for sprite in self._sprites:

--- a/rgkit/render/robotsprite.py
+++ b/rgkit/render/robotsprite.py
@@ -163,7 +163,8 @@ class RobotSprite(object):
         tex_hex = rgb_to_hex(*tex_rgb)
         val = int(self.hp * (1 - delta) + self.hp_next * delta)
         if self.text is None:
-            self.text = self.renderer.draw_text(self.location, val, tex_hex)
+            self.text = self.renderer.draw_text(
+                self.location, val, tex_hex, layer=8)
         self.renderer._win.itemconfig(self.text, text=val, fill=tex_hex)
         self.renderer._win.coords(
             self.text,

--- a/rgkit/render/robotsprite.py
+++ b/rgkit/render/robotsprite.py
@@ -169,10 +169,10 @@ class RobotSprite(object):
             self.text,
             (x + ox +
                 (self.renderer._blocksize -
-                    self.renderer.cell_border_width) / 2,
+                    self.renderer.cell_border_width) // 2,
              y + oy +
                 (self.renderer._blocksize -
-                    self.renderer.cell_border_width) / 2))
+                    self.renderer.cell_border_width) // 2))
 
     def clear(self):
         self.renderer.remove_object(self.square)

--- a/rgkit/render/robotsprite.py
+++ b/rgkit/render/robotsprite.py
@@ -100,15 +100,15 @@ class RobotSprite(object):
                     render_settings.bot_suicide_animation):
                 # explosion animation
                 # expand size (up to 1.5x original size)
-                bot_size = self.renderer._blocksize * (1 + delta / 2)
+                bot_size = self.renderer._blocksize * (1 + delta // 2)
                 # color fade to yellow
                 bot_rgb = blend_colors(bot_rgb, (1, 1, 0), 1 - delta)
 
         # DRAW ARROWS AND BORDER AND CIRCLE
         if self.renderer.show_arrows.get():
             if arrow_fill is not None and self.overlay is None:
-                offset = (self.renderer._blocksize / 2,
-                          self.renderer._blocksize / 2)
+                offset = (self.renderer._blocksize // 2,
+                          self.renderer._blocksize // 2)
                 self.overlay = self.renderer.draw_line(
                     self.location, self.target, layer=5, fill=arrow_fill,
                     offset=offset, width=3.0, arrow=Tkinter.LAST)
@@ -157,7 +157,7 @@ class RobotSprite(object):
         x, y = self.renderer.grid_to_xy(loc)
         ox, oy = self.animation_offset
         tex_rgb = render_settings.text_color_bright \
-            if self.hp > settings.robot_hp / 4 \
+            if self.hp > settings.robot_hp // 4 \
             else render_settings.text_color_dark
         tex_rgb = blend_colors(tex_rgb, bot_color, alpha)
         tex_hex = rgb_to_hex(*tex_rgb)

--- a/rgkit/render/robotsprite.py
+++ b/rgkit/render/robotsprite.py
@@ -10,6 +10,7 @@ from rgkit.render.utils import compute_color
 
 PY3 = sys.version_info[0] == 3
 
+
 class RobotSprite(object):
     def __init__(self, action_info, render):
         self.location = action_info['loc']

--- a/rgkit/render/robotsprite.py
+++ b/rgkit/render/robotsprite.py
@@ -2,11 +2,13 @@ try:
     import Tkinter
 except ImportError:
     import tkinter as Tkinter
+import sys
 from rgkit.settings import settings
 from rgkit.render.settings import settings as render_settings
 from rgkit.render.utils import rgb_to_hex, rgb_tuple_to_hex, blend_colors
 from rgkit.render.utils import compute_color
 
+PY3 = sys.version_info[0] == 3
 
 class RobotSprite(object):
     def __init__(self, action_info, render):
@@ -163,8 +165,9 @@ class RobotSprite(object):
         tex_hex = rgb_to_hex(*tex_rgb)
         val = int(self.hp * (1 - delta) + self.hp_next * delta)
         if self.text is None:
+            layer = 8 if PY3 else 9
             self.text = self.renderer.draw_text(
-                self.location, val, tex_hex, layer=8)
+                self.location, val, tex_hex, layer=layer)
         self.renderer._win.itemconfig(self.text, text=val, fill=tex_hex)
         self.renderer._win.coords(
             self.text,

--- a/rgkit/render/utils.py
+++ b/rgkit/render/utils.py
@@ -29,9 +29,9 @@ def blend_colors(color1, color2, weight):
 def compute_color(player_id, hp, action):
     r, g, b = render_settings.colors[player_id]
     maxclr = min(hp, 50)
-    r += (100 - maxclr * 1.75) / 255
-    g += (100 - maxclr * 1.75) / 255
-    b += (100 - maxclr * 1.75) / 255
+    r += (100 - maxclr * 1.75) // 255
+    g += (100 - maxclr * 1.75) // 255
+    b += (100 - maxclr * 1.75) // 255
     color = (r, g, b)
     if action is 'guard' and render_settings.color_guard is not None:
         color = blend_colors(color, render_settings.color_guard, 0.65)

--- a/rgkit/rg.py
+++ b/rgkit/rg.py
@@ -1,7 +1,7 @@
 from rgkit.settings import settings
 
 
-CENTER_POINT = (int(settings.board_size / 2), int(settings.board_size / 2))
+CENTER_POINT = (int(settings.board_size // 2), int(settings.board_size // 2))
 
 
 def dist(p1, p2):

--- a/rgkit/run.py
+++ b/rgkit/run.py
@@ -412,7 +412,7 @@ def main():
         p1won = sum(p1 > p2 for p1, p2 in scores)
         p2won = sum(p2 > p1 for p1, p2 in scores)
         draw = args.count - p1won - p2won
-        avg_score = [float(sum(x))/len(x) for x in zip(*scores)]
+        avg_score = [float(sum(x)) // len(x) for x in zip(*scores)]
         diff = avg_score[0] - avg_score[1]
         if args.heatmap:
             print_score_grid(scores, args.player1, args.player2, 26)
@@ -432,7 +432,7 @@ def main():
         total_avg_score = list(map(int, (total_avg_score[0] // num_opponents,
                                          total_avg_score[1] // num_opponents)))
         total_diff = int(total_diff // num_opponents)
-        win_rate = (100 * float(total_won + 0.5 * total_draw) /
+        win_rate = (100 * float(total_won + 0.5 * total_draw) //
                     (total_won + total_lost + total_draw))
         print('Overall: [{}, {}, {}] WR: {:<5.1f} Score: {} ({})'.format(
             total_won, total_lost, total_draw, win_rate, total_avg_score,

--- a/rgkit/run.py
+++ b/rgkit/run.py
@@ -338,7 +338,7 @@ def print_score_grid(scores, player1, player2, size):
     max_score = 50
 
     def to_grid(n):
-        return int(round(float(n) / max_score * (size - 1)))
+        return int(round(float(n) // max_score * (size - 1)))
 
     def print_heat(n):
         if n > 9:
@@ -406,7 +406,7 @@ def main():
         total_time = time.time() - start_time
 
         print('{0:6.2f}s per game, {1} games, total {2:.0f}s'.format(
-            total_time / args.count, args.count, total_time))
+            total_time // args.count, args.count, total_time))
         if args.quiet >= 3:
             unmute_all()
         p1won = sum(p1 > p2 for p1, p2 in scores)
@@ -429,9 +429,9 @@ def main():
             repr(avg_score), diff))
 
     if num_opponents > 1:
-        total_avg_score = list(map(int, (total_avg_score[0] / num_opponents,
-                                         total_avg_score[1] / num_opponents)))
-        total_diff = int(total_diff / num_opponents)
+        total_avg_score = list(map(int, (total_avg_score[0] // num_opponents,
+                                         total_avg_score[1] // num_opponents)))
+        total_diff = int(total_diff // num_opponents)
         win_rate = (100 * float(total_won + 0.5 * total_draw) /
                     (total_won + total_lost + total_draw))
         print('Overall: [{}, {}, {}] WR: {:<5.1f} Score: {} ({})'.format(

--- a/test/attack_test.py
+++ b/test/attack_test.py
@@ -62,7 +62,7 @@ class TestAttack(unittest.TestCase):
         self.assertTrue(state2.is_robot((9, 10)))
         damage = settings.robot_hp - state2.robots[9, 10].hp
         self.assertTrue(
-            settings.attack_range[0]/2 <= damage <= settings.attack_range[1]/2)
+            settings.attack_range[0] // 2 <= damage <= settings.attack_range[1] // 2)
 
     def test_attack_does_no_damage_to_teammates(self):
         state = GameState()

--- a/test/attack_test.py
+++ b/test/attack_test.py
@@ -62,7 +62,8 @@ class TestAttack(unittest.TestCase):
         self.assertTrue(state2.is_robot((9, 10)))
         damage = settings.robot_hp - state2.robots[9, 10].hp
         self.assertTrue(
-            settings.attack_range[0] // 2 <= damage <= settings.attack_range[1] // 2)
+            settings.attack_range[0] // 2 <=
+            damage <= settings.attack_range[1] // 2)
 
     def test_attack_does_no_damage_to_teammates(self):
         state = GameState()

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -10,8 +10,11 @@ def test_mapeditor_importable(monkeypatch, capsys):
     out, err = capsys.readouterr()
     assert 'usage: ' in out
 
+
 def test_other_imports():
-    import rgkit.render.robotsprite
-    import rgkit.render.render
-    import rgkit.render.highlightsprite
-    import rgkit.rgcurses
+    from rgkit.render.robotsprite import RobotSprite
+    from rgkit.render.render import Render
+    from rgkit.render.highlightsprite import HighlightSprite
+    from rgkit.rgcurses import RGCurses
+    # prevent flake8 complaining
+    (RobotSprite, Render, HighlightSprite, RGCurses)

--- a/test/test_renames.py
+++ b/test/test_renames.py
@@ -9,3 +9,9 @@ def test_mapeditor_importable(monkeypatch, capsys):
     main()
     out, err = capsys.readouterr()
     assert 'usage: ' in out
+
+def test_other_imports():
+    import rgkit.render.robotsprite
+    import rgkit.render.render
+    import rgkit.render.highlightsprite
+    import rgkit.rgcurses


### PR DESCRIPTION
ok good progress, the issue was with layers covering other layers. Don't quite understand why the fix is Python version specific. So it's usable on py2 and py3 now:

py2 & py3
![image](https://user-images.githubusercontent.com/167319/31856953-63e2a75e-b6c8-11e7-93dc-5ab7a321c365.png)


Not sure if it makes any difference, but I've fixed division to be the same as it was before - int output where there's no `from __future__ import division`.
